### PR TITLE
Ability to understand date and times

### DIFF
--- a/src/main/java/orange/Orange.java
+++ b/src/main/java/orange/Orange.java
@@ -18,7 +18,11 @@ public class Orange {
   private TaskManager taskManager;
 
   public Orange() {
-    storage = new Storage();
+    try {
+      storage = new Storage();
+    } catch (OrangeException o) {
+      System.out.println(o.getCustomMessage());
+    }
     taskManager = new TaskManager();
   }
 

--- a/src/main/java/orange/Ui/Ui.java
+++ b/src/main/java/orange/Ui/Ui.java
@@ -3,7 +3,9 @@ package orange.Ui;
 import orange.task.Task;
 import orange.task.TaskList;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
+import orange.parser.DateParser;
 
 public class Ui {
     private static final String HORIZONTAL_LINE = "\t" + "-".repeat(50);
@@ -69,5 +71,13 @@ public class Ui {
         System.out.println(HORIZONTAL_LINE);
     }
 
+    public static void showMatchingTasks(ArrayList<Task> matchingTasks, LocalDate checkDate) {
+        System.out.println(HORIZONTAL_LINE);
+        System.out.println("Here are the list of tasks that are due on " + DateParser.getStringFromLocalDate(checkDate));
+        for(Task t: matchingTasks) {
+            System.out.println("\t" + t.GetTaskWithCompletion());
+        }
+        System.out.println("You have " + matchingTasks.size() + " tasks in the list.");
+    }
 
 }

--- a/src/main/java/orange/command/CheckOnDateCommand.java
+++ b/src/main/java/orange/command/CheckOnDateCommand.java
@@ -1,0 +1,43 @@
+package orange.command;
+
+import orange.Ui.Ui;
+import orange.exception.OrangeException;
+import orange.parser.DateParser;
+import orange.parser.Parser;
+import orange.task.Deadline;
+import orange.task.Events;
+import orange.task.Task;
+import orange.task.TaskList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+public class CheckOnDateCommand extends Command{
+
+    @Override
+    public void executeCommand() throws OrangeException {
+        LocalDate checkDate = Parser.parseCheckTasksOnDate();
+
+        //Compare against all dates in the list, and list out the dates that are matching with the checkDate
+        ArrayList<Task> matchingTasks = new ArrayList<>();
+        for(Task task: TaskList.getInstance().getTasks()) {
+            if(task.getClass().getName().equals("orange.task.Deadline")) {
+                Deadline d = (Deadline) task;
+                if(d.getLocalDateTime().toLocalDate().isEqual(checkDate)) {
+                    matchingTasks.add(d);
+                }
+            }else if(task.getClass().getName().equals("orange.task.Events")) {
+
+                Events e = (Events) task;
+                System.out.println(DateParser.getStringFromLocalDate(e.getEndLocalDateTime().toLocalDate()));
+                if(e.getEndLocalDateTime().toLocalDate().isEqual(checkDate)) {
+                    matchingTasks.add(e);
+                }
+            }
+        }
+
+        //Send to UI
+        Ui.showMatchingTasks(matchingTasks,checkDate);
+
+    }
+}

--- a/src/main/java/orange/command/DeadlineCommand.java
+++ b/src/main/java/orange/command/DeadlineCommand.java
@@ -2,12 +2,14 @@ package orange.command;
 
 import orange.Ui.Ui;
 import orange.exception.OrangeException;
+import orange.parser.DateParser;
 import orange.parser.Parser;
 import orange.storage.Storage;
 import orange.task.Deadline;
 import orange.task.TaskList;
 import orange.task.Todo;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 public class DeadlineCommand extends Command{

--- a/src/main/java/orange/exception/ExceptionType.java
+++ b/src/main/java/orange/exception/ExceptionType.java
@@ -3,7 +3,7 @@ package orange.exception;
 import orange.task.TaskList;
 
 public enum ExceptionType {
-    UNKNOWN_COMMAND(1, "No idea what that means, start with a keyword man! List of keywords: \"mark\", \"unmark\", \"list\", \"todo\", \"event\", \"deadline\", \"delete\""),
+    UNKNOWN_COMMAND(1, "No idea what that means, start with a keyword man! List of keywords: \"mark\", \"unmark\", \"list\", \"todo\", \"event\", \"deadline\", \"delete\", \"checkondate\""),
     MISSING_DEADLINE(2, "You didn't provide an orange.task.Deadline date and time! Usage: /by [Date And Time orange.task.Deadline orange.task.Task Is Due]"),
     INVALID_TASKNUMBER(3, "You have provided an invalid task number. Try again using a number from the range 0 - " + (TaskList.getInstance().getSize()) + "Usage: mark/unmark/delete [taskNumber] (Add a space between the keyword and taskNumber)" ),
     MISSING_TODO_DESCRIPTION(4, "You have provided an invalid/missing todo description. Todo descriptions cannot be empty. Try again. Usage: todo [todo task description]"),
@@ -17,7 +17,12 @@ public enum ExceptionType {
     MISSING_EVENT_FROMWORD(12, "You have not used the /from in your event command. Try this: event [event task description] /from [Date And Time task starts on] /to [Date And Time task is due]"),
     EXTRA_BY_IN_DEADLINE(13, "You have used extra /by in the deadline command, this is not allowed. Try this: deadline [deadline task description] /by [Date And Time task is due]"),
     EXTRA_FROM_IN_EVENT(14, "You have used extra /from in the event command, this is not allowed. Try this: event [event task description] /from [Date And Time task starts on] /to [Date And Time task is due]"),
-    EXTRA_TO_IN_EVENT(14, "You have used extra /to in the event command, this is not allowed. Try this: event [event task description] /from [Date And Time task starts on] /to [Date And Time task is due]");
+    EXTRA_TO_IN_EVENT(15, "You have used extra /to in the event command, this is not allowed. Try this: event [event task description] /from [Date And Time task starts on] /to [Date And Time task is due]"),
+    INCORRECT_DATE_AND_TIME_FORMAT(16, "Date And Time Format Provided Is Incorrect. Try in this format: yyyy-mm-dd HH:mm"),
+    INVALID_DATE_OR_TIME(17, "You have entered an invalid date or time, the format is correct. Try in this format: yyyy-mm-dd HH:mm"),
+    INVALID_DATE(18, "You have entered an invalid date. Try in this format: yyyy-mm-dd");
+
+
 
 
 

--- a/src/main/java/orange/parser/DateParser.java
+++ b/src/main/java/orange/parser/DateParser.java
@@ -1,0 +1,69 @@
+package orange.parser;
+import orange.exception.OrangeException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static orange.exception.ExceptionType.*;
+
+
+//Converts strings into date objects
+//and date objects into strings
+public class DateParser {
+        public static LocalDateTime getDateTimeObject(String timeAndDate) throws OrangeException {
+            //Accepts date in the format of yyyy-mm-dd time
+            // Regex for matching date and time in "yyyy-mm-dd HH:mm" format
+            String dateTimePattern = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}$";
+
+            Pattern pattern = Pattern.compile(dateTimePattern);
+            LocalDateTime dateTime = null;
+
+            // Check if the input matches the pattern
+            Matcher matcher = pattern.matcher(timeAndDate);
+            if(!matcher.matches()) throw new OrangeException(INCORRECT_DATE_AND_TIME_FORMAT);
+
+            try {
+                // Attempt to parse the input as a date-time in "yyyy-MM-dd HH:mm" format
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+                dateTime = LocalDateTime.parse(timeAndDate, formatter);
+            } catch (DateTimeParseException e) {
+                throw new OrangeException(INVALID_DATE_OR_TIME);
+            }
+                return dateTime;
+        }
+
+        public static String getDifferentFormat(LocalDateTime dateTime) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
+
+            // Convert LocalDateTime to String using the formatter
+            return dateTime.format(formatter);
+        }
+
+
+        // Convert String To LocalDate
+        public static LocalDate getDateObject(String givenDate) throws OrangeException {
+            // Define the format you expect the date to be in
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // Adjust format as needed
+
+            try {
+                // Try parsing the date string using the formatter
+                return LocalDate.parse(givenDate, formatter);
+            } catch (DateTimeParseException e) {
+                // Handle invalid date format
+                throw new OrangeException(INVALID_DATE);
+            }
+        }
+
+        //Convert LocalDate to String
+        public static String getStringFromLocalDate(LocalDate localDate) {
+            // Define the format pattern
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            // Convert LocalDate to String using the formatter
+            return localDate.format(formatter);
+        }
+}

--- a/src/main/java/orange/parser/Parser.java
+++ b/src/main/java/orange/parser/Parser.java
@@ -4,6 +4,8 @@ import orange.exception.ExceptionType;
 import orange.exception.OrangeException;
 import orange.Ui.Ui;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,7 +13,7 @@ import java.util.HashSet;
 import static orange.exception.ExceptionType.*;
 
 public class Parser {
-    private static final HashSet<String> commands = new HashSet<>(Arrays.asList("mark","unmark","list","todo","event","deadline","delete"));
+    private static final HashSet<String> commands = new HashSet<>(Arrays.asList("mark","unmark","list","todo","event","deadline","delete","checkondate"));
     protected static String line;
 
     public Parser(String line) {
@@ -85,6 +87,7 @@ public class Parser {
         } catch(IndexOutOfBoundsException i) {
             throw new OrangeException(MISSING_DEADLINE_DOBY);
         }
+
 
         return new ArrayList<>(Arrays.asList(deadlineTask, doTaskBy));
     }
@@ -205,6 +208,19 @@ public class Parser {
         }
 
         return taskToDelete - 1;
+    }
+
+    public static LocalDate parseCheckTasksOnDate() throws OrangeException {
+        String givenDate = "";
+        try {
+            givenDate = line.substring(11).trim();
+            if (givenDate.isEmpty()) {
+                throw new OrangeException(MISSING_DEADLINE_DESCRIPTION);  // Throw exception if the task is empty after trimming
+            }
+        } catch(IndexOutOfBoundsException i) {
+            throw new OrangeException(MISSING_DEADLINE_DESCRIPTION);
+        }
+        return DateParser.getDateObject(givenDate);
     }
 
 }

--- a/src/main/java/orange/storage/Storage.java
+++ b/src/main/java/orange/storage/Storage.java
@@ -1,5 +1,6 @@
 package orange.storage;
 
+import orange.exception.OrangeException;
 import orange.task.*;
 
 import java.io.FileWriter;
@@ -84,7 +85,7 @@ public class Storage {
     }
 
     //Load Tasks into taskmanager's arraylist
-    private void loadTasks() {
+    private void loadTasks() throws OrangeException {
         try {
             Path taskPath = Paths.get(TASKFILE);
             List<String> lines = Files.readAllLines(taskPath);
@@ -117,7 +118,7 @@ public class Storage {
     }
 
     //Constructor
-    public Storage() {
+    public Storage() throws OrangeException{
         //Initalises task file (creates it if it does not exist)
         try {
             initaliseTaskfile();

--- a/src/main/java/orange/task/Deadline.java
+++ b/src/main/java/orange/task/Deadline.java
@@ -1,17 +1,28 @@
 package orange.task;
 
+import orange.exception.OrangeException;
+import orange.parser.DateParser;
+
+import java.time.LocalDateTime;
+
 public class Deadline extends Task {
 
-  protected String dateAndTime;
+  protected LocalDateTime dateAndTime;
+  protected String newDateTimeString;
+  protected String originalDateTimeString;
 
-  public Deadline(String description, boolean isDone, String dateAndTime) {
+  public Deadline(String description, boolean isDone, String originalDateTimeString) throws OrangeException {
     super(description, isDone);
-    this.dateAndTime = dateAndTime;
+    this.originalDateTimeString = originalDateTimeString;
+    this.dateAndTime = DateParser.getDateTimeObject(originalDateTimeString);
+    this.newDateTimeString = DateParser.getDifferentFormat(dateAndTime);
   }
 
-  public Deadline(String description, String dateAndTime) {
+  public Deadline(String description, String originalDateTimeString) throws OrangeException {
     super(description);
-    this.dateAndTime = dateAndTime;
+    this.originalDateTimeString = originalDateTimeString;
+    this.dateAndTime = DateParser.getDateTimeObject(originalDateTimeString);
+    this.newDateTimeString = DateParser.getDifferentFormat(dateAndTime);
   }
 
   @Override
@@ -26,13 +37,18 @@ public class Deadline extends Task {
   @Override
   public String GetTaskWithCompletion() {
     if (this.isDone) {
-      return "[D][X] " + this.description + " (by: " + dateAndTime + ")";
+      return "[D][X] " + this.description + " (by: " + newDateTimeString + ")";
     } else {
-      return "[D][ ] " + this.description + " " + "(by: " + dateAndTime + ")";
+      return "[D][ ] " + this.description + " " + "(by: " + newDateTimeString + ")";
     }
   }
 
   public String getDateAndTime() {
+    return originalDateTimeString;
+  }
+
+  public LocalDateTime getLocalDateTime() {
     return dateAndTime;
   }
+
 }

--- a/src/main/java/orange/task/Events.java
+++ b/src/main/java/orange/task/Events.java
@@ -1,21 +1,46 @@
 package orange.task;
 
+import orange.exception.OrangeException;
+import orange.parser.DateParser;
+
+import java.time.LocalDateTime;
+
 public class Events extends Task {
 
-  protected String startDateAndTime;
-  protected String endDateAndTime;
+  protected LocalDateTime startDateAndTime;
+  protected String newStartDateTimeString;
+  protected String originalStartDateTimeString;
+
+  protected LocalDateTime endDateAndTime;
+  protected String newEndDateTimeString;
+  protected String originalEndDateTimeString;
+
+
 
   public Events(
-      String description, boolean isDone, String startDateAndTime, String endDateAndTime) {
+      String description, boolean isDone, String originalStartDateTimeString, String originalEndDateTimeString) throws OrangeException {
     super(description, isDone);
-    this.startDateAndTime = startDateAndTime;
-    this.endDateAndTime = endDateAndTime;
+    this.originalStartDateTimeString = originalStartDateTimeString;
+    this.startDateAndTime = DateParser.getDateTimeObject(originalStartDateTimeString);
+    this.newStartDateTimeString = DateParser.getDifferentFormat(startDateAndTime);
+
+
+    this.originalEndDateTimeString = originalEndDateTimeString;
+    this.endDateAndTime = DateParser.getDateTimeObject(originalEndDateTimeString);
+    this.newEndDateTimeString = DateParser.getDifferentFormat(endDateAndTime);
+
   }
 
-  public Events(String description, String startDateAndTime, String endDateAndTime) {
+  public Events(String description, String originalStartDateTimeString, String originalEndDateTimeString) throws OrangeException {
     super(description);
-    this.startDateAndTime = startDateAndTime;
-    this.endDateAndTime = endDateAndTime;
+    this.originalStartDateTimeString = originalStartDateTimeString;
+    this.startDateAndTime = DateParser.getDateTimeObject(originalStartDateTimeString);
+    this.newStartDateTimeString = DateParser.getDifferentFormat(startDateAndTime);
+
+
+    this.originalEndDateTimeString = originalEndDateTimeString;
+    this.endDateAndTime = DateParser.getDateTimeObject(originalEndDateTimeString);
+    this.newEndDateTimeString = DateParser.getDifferentFormat(endDateAndTime);
   }
 
   @Override
@@ -34,27 +59,33 @@ public class Events extends Task {
           + this.description
           + " "
           + "(from: "
-          + startDateAndTime
+          + newStartDateTimeString
           + " to: "
-          + endDateAndTime
+          + newStartDateTimeString
           + ")";
     } else {
       return "[E][ ] "
           + this.description
           + " "
           + "(from: "
-          + startDateAndTime
+          + newStartDateTimeString
           + " to: "
-          + endDateAndTime
+          + newStartDateTimeString
           + ")";
     }
   }
 
   public String getStartDateAndTime() {
-    return startDateAndTime;
+    return originalStartDateTimeString;
   }
 
   public String getEndDateAndTime() {
+    return originalEndDateTimeString;
+  }
+
+  public LocalDateTime getEndLocalDateTime()
+  {
     return endDateAndTime;
   }
+
 }

--- a/src/main/java/orange/task/TaskManager.java
+++ b/src/main/java/orange/task/TaskManager.java
@@ -21,7 +21,7 @@ public class TaskManager {
         commandMap.put("deadline", new DeadlineCommand()::executeCommand);
         commandMap.put("event", new EventCommand()::executeCommand);
         commandMap.put("delete", new DeleteCommand()::executeCommand);
-
+        commandMap.put("checkondate", new CheckOnDateCommand()::executeCommand);
     }
 
     public CommandHandler getTask(String task) {


### PR DESCRIPTION
Chatbot can now understand dates and times passed while creating deadlines and events, provided they are in the yyyy-mm-dd format.

Chatbot can now also display tasks due on a given date (date should be in the yyyy-mm-dd format)